### PR TITLE
Alternate modified strings pot generation

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -32,7 +32,7 @@ function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d
 CHANGED_FILES=$(git diff --name-only $(git merge-base $BRANCH master) $BRANCH)
 
 # Diff commits to this branch
-COMMITS_HASHES=$(git log --graph --abbrev-commit --date=relative master..$BRANCH --pretty=format:%h | cut -c 3-);
+COMMITS_HASHES=$(git log --graph --abbrev=8 --date=relative master..$BRANCH --pretty=format:%h | cut -c 3-);
 
 # Concatenate
 COMMITS_HASHES=$(join_by '\|^' ${COMMITS_HASHES[@]})
@@ -41,7 +41,7 @@ COMMITS_HASHES=$(join_by '\|^' ${COMMITS_HASHES[@]})
 printf "{\n\t" > localci-changed-files.json
 for file in $CHANGED_FILES; do
 	# Get all the lines that changed in our commits
-	LINES=$(git blame -s ${file} | grep "^${COMMITS_HASHES}" | sed -n 's/^[[:xdigit:]]\{5,40\} \{1,5\}\([[:digit:]]\{1,4\}\)).*$/\1/p')
+	LINES=$(git blame -f -s ${file} | grep "^${COMMITS_HASHES}" | sed -n "s|^[[:xdigit:]]\{8\} \{1,5\}${file} \{1,5\}\([[:digit:]]\{1,4\}\)).*$|\1|p")
 	if [ -n "$LINES" ]; then
 		printf '"%s":\n\t[ ' "$file" >> localci-changed-files.json
 		for line in $LINES ; do

--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -50,6 +50,7 @@ for file in $CHANGED_FILES; do
 		printf '"%s":[' "$file" >> localci-changed-files.json
 		lastline=
 		for line in $LINES ; do
+			# Also add previous line, for cases where 'translate' is on one line, and the actual string on the next
 			[[ "$lastline" -ne "$((line-1))" ]] && printf '%d,' $((line-1)) >> localci-changed-files.json
 			printf '%d,' $line >> localci-changed-files.json
 			lastline=$line
@@ -57,7 +58,7 @@ for file in $CHANGED_FILES; do
 		sed -i '' '$ s/,$/],/' localci-changed-files.json # remove last comma
 	fi;
 done;
-sed -i '' '$ s/.$//' localci-changed-files.json # remove last comma
+sed -i '' '$ s/,$//' localci-changed-files.json # remove last comma
 printf '}\n' >> localci-changed-files.json
 
 # if node is installed, d/l node gettext tools and run

--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -52,6 +52,9 @@ for file in $CHANGED_FILES; do
 		printf '"%s":\n\t[ ' "$file" >> localci-changed-files.json
 		for line in $LINES ; do
 			printf '\n\t "%s",' "$line" >> localci-changed-files.json
+			# Also add previous line, for cases where 'translate' is on one line, and the actual string on the next
+			((line--))
+			printf '\n\t "%s",' "$line" >> localci-changed-files.json
 		done;
 		sed -i '' '$ s/.$//' localci-changed-files.json # remove last comma
 		printf '\t],\n' >> localci-changed-files.json

--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -40,6 +40,12 @@ COMMITS_HASHES=$(join_by '\|^' ${COMMITS_HASHES[@]})
 # Output our json file
 printf "{\n\t" > localci-changed-files.json
 for file in $CHANGED_FILES; do
+
+	# No need to blame on a removed file
+	if [ ! -e "$file" ]; then
+		break
+	fi
+
 	# Get all the lines that changed in our commits
 	LINES=$(git blame -f -s ${file} | grep "^${COMMITS_HASHES}" | sed -n "s|^[[:xdigit:]]\{8\} \{1,5\}${file} \{1,5\}\([[:digit:]]\{1,4\}\)).*$|\1|p")
 	if [ -n "$LINES" ]; then

--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -29,7 +29,7 @@ fi
 function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
 
 # All files changed in this branch
-CHANGED_FILES=$(git diff --name-only $(git merge-base $BRANCH master) $BRANCH)
+CHANGED_FILES=$(git diff --name-only $(git merge-base $BRANCH master) $BRANCH '*.js' '*.jsx')
 
 # Diff commits to this branch
 COMMITS_HASHES=$(git log --graph --abbrev=8 --date=relative master..$BRANCH --pretty=format:%h | cut -c 3-);


### PR DESCRIPTION
Fixes #1, probably #2 and #3 as well.

Previous method:`msgcat -u` on master pot and branch pot.
New method: 

1. Get list of changed files in branch
2. Get all commits hashes
3. Use `git blame` to get all the lines changes in commits from [2] on files from [1]
4. Use that information to build a json file, that looks like this:
```
{
	 "client/me/purchases/manage-purchase/index.jsx" :
    [
      "159",
      "160",
      "162",
      "163",
      "164",
      "165",
      "166",
      "167",
      "168",
      "169",
      "175",
      "143"
    ]
}
```
5. i18n-calypso via the [files-map-filter](https://github.com/Automattic/i18n-calypso/tree/add/files-map-filter) branch, is now aware of this file, and will use that if present to only include strings from there files and lines in the output.

needs more testing, but I think it works :)