### PR TITLE
Try no submodule

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -113,12 +113,17 @@ printf '}\n' >> localci-changed-files.json
 rm -f localci-changed-files.json.bak
 
 # if node is installed, d/l node gettext tools and run
-if type "node" &> /dev/null; then
+if type "npx" &> /dev/null; then
+	npx i18n-calypso --format pot --lines-filter localci-changed-files.json --output-file ./localci-new-strings.pot $CHANGED_FILES
+elif type "node" &> /dev/null; then
 	cd gp-localci-client/i18n-calypso
 	git submodule init; git submodule update
 	npm install
 	cd -
 	node gp-localci-client/i18n-calypso/bin --format pot --lines-filter localci-changed-files.json --output-file ./localci-new-strings.pot $CHANGED_FILES
+else
+	echo "npx and node not found.  Failed to extract strings."
+	exit 1
 fi
 
 # Cleanup


### PR DESCRIPTION
Provide `npx`-based alternative to use latest `i18n-calypso`, which may be better cached and more up to date than the submodule provided by this repo.

- `npx` has been included with `npm` since `5.2.0` ([#](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)).
- Latest Node LTS ships with `npm@5.6.0` ([#](https://nodejs.org/en/download/))

It should be reasonable to rely on the presence of `npx` for optimal experience, which can rely on caching or project-installed modules without the need to clone and npm install `i18n-calypso` from the repository.

That's ideal for avoiding the checkout pointing to an old sha of the `i18n-calypso` repo.
This avoids needing to keep the submodule up to date.
This avoids time-consuming and potentially unecessary `npm install` on the submodule

✅ ~Todo:~

~What do we know about [usage](https://github.com/search?q=org%3AAutomattic+gp-localci-client&type=Code)?~
~The submodule could be maintained as a fallback. Prefer `npx`, fallback to submodule checkout and npm install on submodule.~

See exploration and testing in https://github.com/Automattic/wp-calypso/pull/25817

Seems to work well with `npx`: https://circleci.com/gh/Automattic/wp-calypso/98517