### PR TITLE
Set errexit option so errors are returned as failure

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 # This script is intended to run on a branch.
 # It generates master and branch pot files
 # and then distills them to find the unique


### PR DESCRIPTION
Errors occurring at an arbitrary command within the script were not being surfaced to the shell.

Add `errexit` so any errors encountered while running the script exit and become visible to the shell.

See (**Build New Strings .pot (0)**):

- Script errors, shell happily continues: https://circleci.com/gh/Automattic/wp-calypso/99977
- Script errors, shell sees error (and job fails): https://circleci.com/gh/Automattic/wp-calypso/99985