### PR TITLE
Revert "Set errexit option so errors are returned as failure"

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -o errexit
-
 # This script is intended to run on a branch.
 # It generates master and branch pot files
 # and then distills them to find the unique


### PR DESCRIPTION
Reverts Automattic/gp-localci-client#13

This is making `echo "$ANY_CHANGED_FILES" | grep -e '.jsx$' -e '\.js$'` bomb when there are no js or jsx files in the commit.