### PR TITLE
Set errexit option so errors are returned as failure :: Take 2

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -55,7 +55,7 @@ if [[ "$CI_PULL_REQUEST" ]]; then
 	echo "LocalCI - fetching $FILESURL"
 	GH_FILESURL_CONTENT=$(auth_gh_curl $FILESURL)
 
-	# Disable exit on error, this section uses non-0 exit codes
+	# Disable exit on error. This section checks for non-0 exit codes
 	set +o errexit
 
 	ANY_CHANGED_FILES=$(echo $GH_FILESURL_CONTENT | jq -r '.[] .filename' )

--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -54,16 +54,22 @@ if [[ "$CI_PULL_REQUEST" ]]; then
 	COMMITSURL=https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/${CI_PULL_REQUEST##*/}/commits
 	echo "LocalCI - fetching $FILESURL"
 	GH_FILESURL_CONTENT=$(auth_gh_curl $FILESURL)
+
+	# Disable exit on error, this section uses non-0 exit codes
+	set +o errexit
+
 	ANY_CHANGED_FILES=$(echo $GH_FILESURL_CONTENT | jq -r '.[] .filename' )
 	if [ $? -ne 0 ]; then
 	    echo "Error parsing $FILESURL:"
 	    echo $GH_FILESURL_CONTENT
 	fi
+
 	CHANGED_FILES=$(echo "$ANY_CHANGED_FILES" | grep -e '.jsx$' -e '\.js$' )
 	if [ $? -ne 0 ]; then
 	    echo "No JS files changed."
 	    exit 0
 	fi
+
 	echo "LocalCI - fetching $COMMITSURL"
 	GH_COMMITSURL_CONTENT=$(auth_gh_curl $COMMITSURL)
 	COMMITS_HASHES=$(echo $GH_COMMITSURL_CONTENT | jq -r '.[] .sha');
@@ -71,6 +77,10 @@ if [[ "$CI_PULL_REQUEST" ]]; then
 	    echo "Error parsing $COMMITSURL:"
 	    echo $GH_COMMITSURL_CONTENT
 	fi
+
+	# Re-enable exit on error
+	set -o errexit
+
 else
 	echo "LocalCI - processing branch $BRANCH"
 	CHANGED_FILES=$(git diff --name-only $(git merge-base $BRANCH master) $BRANCH -- '*.js' '*.jsx')

--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 # This script is intended to run on a branch.
 # It generates master and branch pot files
 # and then distills them to find the unique


### PR DESCRIPTION
Reverts Automattic/gp-localci-client#14

Second attempt at #13 that was unexpectedly failing when no `js`/`jsx` files were found.

> Errors occurring at an arbitrary command within the script were not being surfaced to the shell.
> 
> Add `errexit` so any errors encountered while running the script exit and become visible to the shell.
> 
> See (**Build New Strings .pot (0)**):
> 
> - Script errors, shell happily continues: https://circleci.com/gh/Automattic/wp-calypso/99977
> - Script errors, shell sees error (and job fails): https://circleci.com/gh/Automattic/wp-calypso/99985

Disables the `errexit` for blocks that expect non-0 exit codes.