### PR TITLE
Convert CHANGED_FILES to single line prior to passing it as input to the make pot CLI

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -124,6 +124,9 @@ printf '}\n' >> localci-changed-files.json
 # remove throwaway file created by cross-platform sed command
 rm -f localci-changed-files.json.bak
 
+# convert CHANGED_FILES to single line input
+CHANGED_FILES="$(tr '\n' ' ' <<<$CHANGED_FILES)"
+
 # if node is installed, d/l node gettext tools and run
 if type "npx" &> /dev/null; then
 	npx @automattic/wp-babel-makepot "$CHANGED_FILES" -l localci-changed-files.json -d "./build/pot" -o ./localci-new-strings.pot


### PR DESCRIPTION
Converts `CHANGED_FILES` variable to single line by replacing new line characters `\n` with single space character ` `.

Testing instructions:
* Checkout any Calypso branch that has multiple files changes
* Clone this repo in Calypso's root
* Print `CHANGED_FILES` after the conversion (`generate-new-strings-pot.sh:128`) with `echo $CHANGED_FILES`
* Run `bash gp-localci-client/generate-new-strings-pot.sh "" "" "/dev/null"`
* Confirm changed files are printed out on a single line separated by a single space character