### PR TITLE
Read default branch name from env variable

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -3,9 +3,12 @@
 set -o errexit
 
 # This script is intended to run on a branch.
-# It generates master and branch pot files
+# It generates default and branch pot files
 # and then distills them to find the unique
 # (new or changed) strings in the branch.
+
+# Use `master` as fallback for default branch name when variable is not set
+DEFAULT_BRANCH=${DEFAULT_BRANCH="master"}
 
 if [[ "$1" ]]; then
 	BRANCH=$1
@@ -22,7 +25,7 @@ if [[ "$3" ]]; then
 fi
 
 # bail if we don't have good branch information
-if [[ "$BRANCH" == "master" ]]; then
+if [[ "$BRANCH" == "$DEFAULT_BRANCH" ]]; then
 	exit 0
 elif [[ "$BRANCH" == "HEAD" ]]; then
 	exit 1
@@ -83,8 +86,8 @@ if [[ "$CI_PULL_REQUEST" ]]; then
 
 else
 	echo "LocalCI - processing branch $BRANCH"
-	CHANGED_FILES=$(git diff --name-only $(git merge-base $BRANCH master) $BRANCH -- '*.js' '*.jsx' '*.ts' '*.tsx')
-	COMMITS_HASHES=$(git log master..$BRANCH --pretty=format:%H);
+	CHANGED_FILES=$(git diff --name-only $(git merge-base $BRANCH $DEFAULT_BRANCH) $BRANCH -- '*.js' '*.jsx' '*.ts' '*.tsx')
+	COMMITS_HASHES=$(git log $DEFAULT_BRANCH..$BRANCH --pretty=format:%H);
 fi
 
 # Bail if no files were changed in this branch

--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -7,8 +7,9 @@ set -o errexit
 # and then distills them to find the unique
 # (new or changed) strings in the branch.
 
-# Use `master` as fallback for default branch name when variable is not set
-DEFAULT_BRANCH=${DEFAULT_BRANCH="master"}
+if [ -z "$DEFAULT_BRANCH" ]; then
+	DEFAULT_BRANCH=$(git branch -al | grep HEAD | awk -F/ '{print $4}')
+fi
 
 if [[ "$1" ]]; then
 	BRANCH=$1


### PR DESCRIPTION
This update removes the hardcoded reference to `master` branch and reads the default branch name from an env variable `DEFAULT_BRANCH` instead. For compatibility reasons, `master` has been set as a fallback value when the variable is no present.

Testing instructions:
- Checkout https://github.com/Automattic/wp-calypso/ and checkout `update/circle-ci-translate-job-default-branch` branch
- Change CWD to the directory where `wp-calypso` was cloned
- Run `DEFAULT_BRANCH=trunk bash /path/to/gp-localci-client/generate-new-strings-pot.sh update/circle-ci-translate-job-default-branch be9639516116d060946e35c2ed9ec480ebaa64d1 ./pot-output`:
	-- first parameter is the branch that will be compared against the default branch
	-- second parameter is the sha1 of the latest commit 
	-- third parameter is the output directory
- Inspect `pot-output` directory and confirm `localci-new-strings.pot` has been generated and contains the expected strings