### PR TITLE
Use Basic Authentication instead of query params

### DIFF
--- a/generate-new-strings-pot.sh
+++ b/generate-new-strings-pot.sh
@@ -36,9 +36,9 @@ fi
 function auth_gh_curl() {
 	local URL=$1;
 	if [[ -n "${LOCALCI_APP_ID}" && -n "${LOCALCI_APP_SECRET}" ]] ; then
-		URL="$URL?client_id=${LOCALCI_APP_ID}&client_secret=${LOCALCI_APP_SECRET}"
+		AUTH="-u ${LOCALCI_APP_ID}:${LOCALCI_APP_SECRET}"
 	fi
-    curl -s $URL
+    curl -s $AUTH $URL
 }
 
 function move_pot_to_output() {


### PR DESCRIPTION
**Description:**
[GitHub is deprecating authentication through query params](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/). This PR updates the script to use Basic Authentication instead.

**Changes:**
* Remove authentication query params
* Use curl's `-u` flag for basic authentication

**Testing instructions:**
* Review code changes
* Check `translate` job in https://github.com/Automattic/wp-calypso/pull/49819 and confirm `gp-localci-client` is working as expected